### PR TITLE
仓库中没有data-export-sdk:1.7.2-SNAPSHOT文件，只有data-export-sdk:1.7.2文件

### DIFF
--- a/server/fisco-bcos-browser/build.gradle
+++ b/server/fisco-bcos-browser/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile spring,spring_boot,jaxb,logger,mysql,io,jackson,swagger
     compile "com.github.briandilley.jsonrpc4j:jsonrpc4j:1.5.1"
     compile "org.apache.commons:commons-lang3:3.10"
-    compile ('com.webank:data-export-sdk:1.7.2-SNAPSHOT'){
+    compile ('com.webank:data-export-sdk:1.7.2'){
         exclude group: 'ch.qos.logback', module: '*'
     }
 


### PR DESCRIPTION
老师您好，我注意到仓库中没有data-export-sdk:1.7.2-SNAPSHOT文件，只有data-export-sdk:1.7.2文件。